### PR TITLE
Added extra margin for modern delivery platform heading in mobile mode

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -459,8 +459,10 @@ header {
     .modern-delivery-platform {
       margin-top: 60rem; } }
   .modern-delivery-platform h2 {
+    display: block;
     font-size: 2.8em;
-    margin-bottom: 0.8em; }
+    margin: 0 auto 0.8em auto;
+    width: 90%; }
   @media (min-width: 768px) {
     .modern-delivery-platform > div {
       display: grid;

--- a/sass/_layout.scss
+++ b/sass/_layout.scss
@@ -473,8 +473,10 @@ header {
 }
 
   h2 {
+    display: block;
     font-size: 2.8em;
-    margin-bottom: 0.8em;
+    margin: 0 auto 0.8em auto;
+    width: 90%;
   }
 
   & > div {


### PR DESCRIPTION
The heading will flow into 2 lines if the device width becomes small.